### PR TITLE
Fix options persistence and modernize UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,6 @@ This extension only accesses the unread count via the Atom feed. It does not rea
 
 ## Options
 Open the extension options to choose the badge color and notification sound.
+You can select one of the bundled sounds or upload your own custom file.
 Your preferences are stored using `chrome.storage.sync` so they will be
 restored the next time you open Chrome.

--- a/README.md
+++ b/README.md
@@ -28,3 +28,5 @@ This extension only accesses the unread count via the Atom feed. It does not rea
 
 ## Options
 Open the extension options to choose the badge color and notification sound.
+Your preferences are stored using `chrome.storage.sync` so they will be
+restored the next time you open Chrome.

--- a/background.js
+++ b/background.js
@@ -42,8 +42,13 @@ async function updateUnreadCount() {
       });
       if (sound !== 'none') {
         try {
-          const audio = new Audio(sound);
-          audio.play();
+          const src = sound.startsWith('data:')
+            ? sound
+            : chrome.runtime.getURL(sound);
+          const audio = new Audio(src);
+          audio.play().catch((e) => {
+            console.error('Failed to play sound', e);
+          });
         } catch (e) {
           console.error('Failed to play sound', e);
         }

--- a/background.js
+++ b/background.js
@@ -22,7 +22,10 @@ async function updateUnreadCount() {
     const match = text.match(/<fullcount>(\d+)<\/fullcount>/i);
     const count = match ? parseInt(match[1], 10) : NaN;
     if (isNaN(count)) throw new Error('fullcount not found');
-    const { badgeColor = DEFAULT_BADGE_COLOR, sound = 'none' } = await chrome.storage.sync.get(['badgeColor', 'sound']);
+    const { badgeColor, sound } = await chrome.storage.sync.get({
+      badgeColor: DEFAULT_BADGE_COLOR,
+      sound: 'none'
+    });
     await chrome.action.setBadgeBackgroundColor({ color: badgeColor });
     if (isNaN(count) || count === 0) {
       await chrome.action.setBadgeText({ text: '' });

--- a/options.css
+++ b/options.css
@@ -1,2 +1,31 @@
-body { font-family: Arial, sans-serif; padding: 10px; }
-section { margin-bottom: 10px; }
+body {
+  font-family: Arial, sans-serif;
+  padding: 20px;
+  background: #f6f6f6;
+}
+
+.container {
+  max-width: 480px;
+  margin: 0 auto;
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+section {
+  margin-bottom: 15px;
+  display: flex;
+  flex-direction: column;
+}
+
+.status {
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  color: #4caf50;
+}
+
+@media (prefers-color-scheme: dark) {
+  body { background: #222; color: #eee; }
+  .container { background: #333; box-shadow: none; }
+}

--- a/options.html
+++ b/options.html
@@ -6,22 +6,25 @@
   <link rel="stylesheet" href="options.css">
 </head>
 <body>
-  <h1>Extension Options</h1>
-  <section>
-    <label for="badgeColor">Badge color:</label>
-    <input type="color" id="badgeColor">
-  </section>
-  <section>
-    <label for="soundSelect">Notification sound:</label>
-    <select id="soundSelect">
-      <option value="none">None</option>
-      <option value="sounds/ding.mp3">Ding</option>
-      <option value="sounds/chime.mp3">Chime</option>
-      <option value="sounds/notify.mp3">Notify</option>
-      <option value="custom">Custom...</option>
-    </select>
-    <input type="file" id="customSound" accept="audio/*" style="display:none">
-  </section>
+  <div class="container">
+    <h1>Extension Options</h1>
+    <section>
+      <label for="badgeColor">Badge color:</label>
+      <input type="color" id="badgeColor">
+    </section>
+    <section>
+      <label for="soundSelect">Notification sound:</label>
+      <select id="soundSelect">
+        <option value="none">None</option>
+        <option value="sounds/ding.mp3">Ding</option>
+        <option value="sounds/chime.mp3">Chime</option>
+        <option value="sounds/notify.mp3">Notify</option>
+        <option value="custom">Custom...</option>
+      </select>
+      <input type="file" id="customSound" accept="audio/*" style="display:none">
+    </section>
+    <div id="status" class="status"></div>
+  </div>
   <script src="options.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure badge color and sound options persist via `chrome.storage.sync`
- give the options page a modern, responsive layout
- note options persistence in docs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685fca9a1658832f8f0ae6fb8a9f6cb8