### PR TITLE
Fix notification sound

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Gmail Badge Notifier is a lightweight Chrome extension that shows the number of 
 - Periodically polls Gmail's Atom feed to determine the number of unread emails.
 - Displays this number on a red badge in the Chrome toolbar.
 - Sends a desktop notification when new mail arrives.
-- Badge and notification colors are configurable from the options page.
+- Badge color and notification sound are configurable from the options page.
 - Automatically hides the badge when there are no unread messages.
 - Runs in the background using the `chrome.alarms` API from Manifest V3.
 - Opens Gmail or activates the existing tab when clicking the extension icon.

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Gmail Badge Notifier",
   "description": "Lightweight and privacy-friendly extension that displays the number of unread messages on Gmail.",
   "version": "1.0",
-  "permissions": ["alarms", "tabs", "notifications", "storage"],
+  "permissions": ["alarms", "tabs", "notifications", "storage", "offscreen"],
   "host_permissions": ["https://mail.google.com/*"],
   "background": {
     "service_worker": "background.js"

--- a/offscreen.html
+++ b/offscreen.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Offscreen Audio</title>
+</head>
+<body>
+  <script src="offscreen.js"></script>
+</body>
+</html>

--- a/offscreen.js
+++ b/offscreen.js
@@ -1,0 +1,12 @@
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.action === 'play' && message.src) {
+    try {
+      const audio = new Audio(message.src);
+      audio.play().catch((e) => {
+        console.error('Failed to play sound', e);
+      });
+    } catch (e) {
+      console.error('Failed to play sound', e);
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- enable offscreen documents to handle notification sounds
- add helper to create offscreen document and send playback commands
- play audio through the offscreen page
- document customizable notification sounds in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_685fda255cf8832fbffd11db58628e05